### PR TITLE
Link to README.md in both crates' Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "A graph visualization program"
 keywords = ["visualization", "svg", "render", "dot", "graphviz"]
 license = "MIT"
+readme = "README.md"
 repository = "https://github.com/nadavrot/layout"
 
 # If you are looking for the library, see the `layout` directory in this repository.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "layout-cli"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Nadav Rotem <nadav256@gmail.com>"]
 edition = "2018"
 description = "A graph visualization program"
@@ -25,7 +25,7 @@ bench = false
 members = ["layout"]
 
 [dependencies]
-layout-rs = { path = "layout", features = ["log"], version = "0.1.0" }
+layout-rs = { path = "layout", features = ["log"], version = "0.1.1" }
 clap = "4.0.18"
 log = "0.4.17"
 env_logger = "0.9"

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ can parse Graphviz dot files and render them.
 Add the following to `Cargo.toml`:
 
 ```toml
-layout-rs = "0.1.0" # or
-layout-rs = { version = "0.1.0", features = ["log"] }
+layout-rs = "0.1.1" # or
+layout-rs = { version = "0.1.1", features = ["log"] }
 ```
 
 Load, parse and print the AST:

--- a/layout/Cargo.toml
+++ b/layout/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "A graph visualization program"
 keywords = ["visualization", "svg", "render", "dot", "graphviz"]
 license = "MIT"
+readme = "../README.md"
 repository = "https://github.com/nadavrot/layout"
 
 # Renaming the library allows us to publish the crate as `layout-rs`,

--- a/layout/Cargo.toml
+++ b/layout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "layout-rs"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Nadav Rotem <nadav256@gmail.com>"]
 edition = "2018"
 description = "A graph visualization program"

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -18,8 +18,8 @@ This crate provides an API for parsing DOT files.
 Add the following to `Cargo.toml`:
 
 ```toml
-layout-rs = "0.1.0" # or
-layout-rs = { version = "0.1.0", features = ["log"] }
+layout-rs = "0.1.1" # or
+layout-rs = { version = "0.1.1", features = ["log"] }
 ```
 
 Load, parse and print the AST:


### PR DESCRIPTION
Link to `README.md` in both crates, so that when they're published, it shows up in crates.io