### PR TITLE
Cargo.toml: add 'log' feature.

### DIFF
--- a/layout/Cargo.toml
+++ b/layout/Cargo.toml
@@ -18,5 +18,8 @@ repository = "https://github.com/nadavrot/layout"
 [lib]
 name = "layout"
 
+[features]
+log = ["dep:log"]
+
 [dependencies]
 log = { version = "0.4.17", optional = true }


### PR DESCRIPTION
The layout crate has a few calls to `log::info!()` guarded by a `#[cfg(feature = "log")]` conditional. This commit declares the `log` feature so that users of the crate can enable such debug messages.