### PR TITLE
fix(parser): remove `println!` statement in parser

### DIFF
--- a/layout/src/gv/parser/parser.rs
+++ b/layout/src/gv/parser/parser.rs
@@ -166,7 +166,6 @@ impl DotParser {
                         Result::Ok(ns)
                     }
                     _ => {
-                        println!("{:?}", self.tok);
                         to_error("Unsupported token")
                     }
                 }
@@ -205,7 +204,6 @@ impl DotParser {
             }
 
             _ => {
-                println!("{:?}", self.tok);
                 to_error("Unknown token")
             }
         }


### PR DESCRIPTION
These seem to be left over debug statements and cause issues when attempting to consume  the `stdout` of a binary using this library.