### PR TITLE
Custom properties

### DIFF
--- a/layout/src/backends/svg.rs
+++ b/layout/src/backends/svg.rs
@@ -208,13 +208,7 @@ impl RenderBackend for SVGWriter {
         self.content.push_str(&line1);
     }
 
-    fn draw_text(
-        &mut self,
-        xy: Point,
-        text: &str,
-        look: &StyleAttr,
-        
-    ) {
+    fn draw_text(&mut self, xy: Point, text: &str, look: &StyleAttr) {
         let len = text.len();
 
         let font_class = self.get_or_create_font_style(look.font_size);
@@ -331,7 +325,13 @@ impl RenderBackend for SVGWriter {
         self.counter += 1;
     }
 
-    fn draw_line(&mut self, start: Point, stop: Point, look: &StyleAttr,properties: Option<String>) {
+    fn draw_line(
+        &mut self,
+        start: Point,
+        stop: Point,
+        look: &StyleAttr,
+        properties: Option<String>,
+    ) {
         let stroke_width = look.line_width;
         let stroke_color = look.line_color;
         let props = properties.unwrap_or_default();

--- a/layout/src/backends/svg.rs
+++ b/layout/src/backends/svg.rs
@@ -163,8 +163,10 @@ impl RenderBackend for SVGWriter {
         let stroke_color = look.line_color;
         let rounded_px = look.rounded;
         let line1 = format!(
-            "<rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" fill=\"{}\" 
-            stroke-width=\"{}\" stroke=\"{}\" rx=\"{}\" {} {}/>\n",
+            "<g {props}>\n
+            <rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" fill=\"{}\" 
+            stroke-width=\"{}\" stroke=\"{}\" rx=\"{}\" {} />\n
+            </g>\n",
             xy.x,
             xy.y,
             size.x,
@@ -173,8 +175,7 @@ impl RenderBackend for SVGWriter {
             stroke_width,
             stroke_color.to_web_color(),
             rounded_px,
-            clip_option,
-            props,
+            clip_option
         );
         self.content.push_str(&line1);
     }
@@ -192,16 +193,17 @@ impl RenderBackend for SVGWriter {
         let stroke_color = look.line_color;
         let props = properties.unwrap_or_default();
         let line1 = format!(
-            "<ellipse cx=\"{}\" cy=\"{}\" rx=\"{}\" ry=\"{}\" fill=\"{}\" 
-            stroke-width=\"{}\" stroke=\"{}\" {}/>\n",
+            "<g {props}>\n
+            <ellipse cx=\"{}\" cy=\"{}\" rx=\"{}\" ry=\"{}\" fill=\"{}\" 
+            stroke-width=\"{}\" stroke=\"{}\"/>\n
+            </g>\n",
             xy.x,
             xy.y,
             size.x / 2.,
             size.y / 2.,
             fill_color.to_web_color(),
             stroke_width,
-            stroke_color.to_web_color(),
-                props,
+            stroke_color.to_web_color()
         );
         self.content.push_str(&line1);
     }
@@ -211,6 +213,7 @@ impl RenderBackend for SVGWriter {
         xy: Point,
         text: &str,
         look: &StyleAttr,
+        
     ) {
         let len = text.len();
 
@@ -301,17 +304,18 @@ impl RenderBackend for SVGWriter {
         let stroke_color = look.line_color;
         let props = properties.unwrap_or_default();
         let line = format!(
-            "<path id=\"arrow{}\" d=\"{}\" \
+            "<g {props}>\n
+            <path id=\"arrow{}\" d=\"{}\" \
             stroke=\"{}\" stroke-width=\"{}\" {} {} {} 
-            fill=\"transparent\" {} />\n",
+            fill=\"transparent\" />\n
+            </g>\n",
             self.counter,
             path_builder.as_str(),
             stroke_color.to_web_color(),
             stroke_width,
             dash,
             start,
-            end,
-            props
+            end
         );
         self.content.push_str(&line);
 
@@ -332,15 +336,16 @@ impl RenderBackend for SVGWriter {
         let stroke_color = look.line_color;
         let props = properties.unwrap_or_default();
         let line1 = format!(
-            "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" stroke-width=\"{}\"
-             stroke=\"{}\" {} />\n",
+            "<g {props}>\n
+             <line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" stroke-width=\"{}\"
+             stroke=\"{}\" />\n
+             </g>\n",
             start.x,
             start.y,
             stop.x,
             stop.y,
             stroke_width,
-            stroke_color.to_web_color(),
-            props
+            stroke_color.to_web_color()
         );
         self.content.push_str(&line1);
     }

--- a/layout/src/backends/svg.rs
+++ b/layout/src/backends/svg.rs
@@ -148,6 +148,7 @@ impl RenderBackend for SVGWriter {
         xy: Point,
         size: Point,
         look: &StyleAttr,
+        properties: Option<String>,
         clip: Option<ClipHandle>,
     ) {
         self.grow_window(xy, size);
@@ -156,14 +157,14 @@ impl RenderBackend for SVGWriter {
         if let Option::Some(clip_id) = clip {
             clip_option = format!("clip-path=\"url(#C{})\"", clip_id);
         }
-
+        let props = properties.unwrap_or_default();
         let fill_color = look.fill_color.unwrap_or_else(Color::transparent);
         let stroke_width = look.line_width;
         let stroke_color = look.line_color;
         let rounded_px = look.rounded;
         let line1 = format!(
             "<rect x=\"{}\" y=\"{}\" width=\"{}\" height=\"{}\" fill=\"{}\" 
-            stroke-width=\"{}\" stroke=\"{}\" rx=\"{}\" {} />\n",
+            stroke-width=\"{}\" stroke=\"{}\" rx=\"{}\" {} {}/>\n",
             xy.x,
             xy.y,
             size.x,
@@ -172,32 +173,45 @@ impl RenderBackend for SVGWriter {
             stroke_width,
             stroke_color.to_web_color(),
             rounded_px,
-            clip_option
+            clip_option,
+            props,
         );
         self.content.push_str(&line1);
     }
 
-    fn draw_circle(&mut self, xy: Point, size: Point, look: &StyleAttr) {
+    fn draw_circle(
+        &mut self,
+        xy: Point,
+        size: Point,
+        look: &StyleAttr,
+        properties: Option<String>,
+    ) {
         self.grow_window(xy, size);
         let fill_color = look.fill_color.unwrap_or_else(Color::transparent);
         let stroke_width = look.line_width;
         let stroke_color = look.line_color;
-
+        let props = properties.unwrap_or_default();
         let line1 = format!(
             "<ellipse cx=\"{}\" cy=\"{}\" rx=\"{}\" ry=\"{}\" fill=\"{}\" 
-            stroke-width=\"{}\" stroke=\"{}\"/>\n",
+            stroke-width=\"{}\" stroke=\"{}\" {}/>\n",
             xy.x,
             xy.y,
             size.x / 2.,
             size.y / 2.,
             fill_color.to_web_color(),
             stroke_width,
-            stroke_color.to_web_color()
+            stroke_color.to_web_color(),
+                props,
         );
         self.content.push_str(&line1);
     }
 
-    fn draw_text(&mut self, xy: Point, text: &str, look: &StyleAttr) {
+    fn draw_text(
+        &mut self,
+        xy: Point,
+        text: &str,
+        look: &StyleAttr,
+    ) {
         let len = text.len();
 
         let font_class = self.get_or_create_font_style(look.font_size);
@@ -233,6 +247,7 @@ impl RenderBackend for SVGWriter {
         dashed: bool,
         head: (bool, bool),
         look: &StyleAttr,
+        properties: Option<String>,
         text: &str,
     ) {
         // Control points as defined in here:
@@ -284,18 +299,19 @@ impl RenderBackend for SVGWriter {
 
         let stroke_width = look.line_width;
         let stroke_color = look.line_color;
-
+        let props = properties.unwrap_or_default();
         let line = format!(
             "<path id=\"arrow{}\" d=\"{}\" \
             stroke=\"{}\" stroke-width=\"{}\" {} {} {} 
-            fill=\"transparent\" />\n",
+            fill=\"transparent\" {} />\n",
             self.counter,
             path_builder.as_str(),
             stroke_color.to_web_color(),
             stroke_width,
             dash,
             start,
-            end
+            end,
+            props
         );
         self.content.push_str(&line);
 
@@ -311,18 +327,20 @@ impl RenderBackend for SVGWriter {
         self.counter += 1;
     }
 
-    fn draw_line(&mut self, start: Point, stop: Point, look: &StyleAttr) {
+    fn draw_line(&mut self, start: Point, stop: Point, look: &StyleAttr,properties: Option<String>) {
         let stroke_width = look.line_width;
         let stroke_color = look.line_color;
+        let props = properties.unwrap_or_default();
         let line1 = format!(
             "<line x1=\"{}\" y1=\"{}\" x2=\"{}\" y2=\"{}\" stroke-width=\"{}\"
-             stroke=\"{}\" />\n",
+             stroke=\"{}\" {} />\n",
             start.x,
             start.y,
             stop.x,
             stop.y,
             stroke_width,
-            stroke_color.to_web_color()
+            stroke_color.to_web_color(),
+            props
         );
         self.content.push_str(&line1);
     }

--- a/layout/src/core/format.rs
+++ b/layout/src/core/format.rs
@@ -66,14 +66,15 @@ pub trait RenderBackend {
         xy: Point,
         size: Point,
         look: &StyleAttr,
+        properties:Option<String>,
         clip: Option<ClipHandle>,
     );
 
     /// Draw a line between \p start and \p stop.
-    fn draw_line(&mut self, start: Point, stop: Point, look: &StyleAttr);
+    fn draw_line(&mut self, start: Point, stop: Point, look: &StyleAttr,properties:Option<String>);
 
     /// Draw an ellipse with the center \p xy, and size \p size.
-    fn draw_circle(&mut self, xy: Point, size: Point, look: &StyleAttr);
+    fn draw_circle(&mut self, xy: Point, size: Point, look: &StyleAttr,properties:Option<String>);
 
     /// Draw a labe.
     fn draw_text(&mut self, xy: Point, text: &str, look: &StyleAttr);
@@ -85,6 +86,7 @@ pub trait RenderBackend {
         dashed: bool,
         head: (bool, bool),
         look: &StyleAttr,
+        properties:Option<String>,
         text: &str,
     );
 

--- a/layout/src/core/format.rs
+++ b/layout/src/core/format.rs
@@ -66,15 +66,27 @@ pub trait RenderBackend {
         xy: Point,
         size: Point,
         look: &StyleAttr,
-        properties:Option<String>,
+        properties: Option<String>,
         clip: Option<ClipHandle>,
     );
 
     /// Draw a line between \p start and \p stop.
-    fn draw_line(&mut self, start: Point, stop: Point, look: &StyleAttr,properties:Option<String>);
+    fn draw_line(
+        &mut self,
+        start: Point,
+        stop: Point,
+        look: &StyleAttr,
+        properties: Option<String>,
+    );
 
     /// Draw an ellipse with the center \p xy, and size \p size.
-    fn draw_circle(&mut self, xy: Point, size: Point, look: &StyleAttr,properties:Option<String>);
+    fn draw_circle(
+        &mut self,
+        xy: Point,
+        size: Point,
+        look: &StyleAttr,
+        properties: Option<String>,
+    );
 
     /// Draw a labe.
     fn draw_text(&mut self, xy: Point, text: &str, look: &StyleAttr);
@@ -86,7 +98,7 @@ pub trait RenderBackend {
         dashed: bool,
         head: (bool, bool),
         look: &StyleAttr,
-        properties:Option<String>,
+        properties: Option<String>,
         text: &str,
     );
 

--- a/layout/src/std_shapes/render.rs
+++ b/layout/src/std_shapes/render.rs
@@ -151,7 +151,8 @@ fn render_record(
             self.canvas.draw_rect(
                 Point::new(loc.x - size.x / 2., loc.y - size.y / 2.),
                 Point::new(size.x, size.y),
-                &self.look,Option::None,
+                &self.look,
+                Option::None,
                 self.clip_handle,
             );
         }
@@ -180,7 +181,8 @@ fn render_record(
     canvas.draw_rect(
         Point::new(loc.x - size.x / 2., loc.y - size.y / 2.),
         Point::new(size.x, size.y),
-        &look,Option::None,
+        &look,
+        Option::None,
         Option::None,
     );
 }
@@ -478,9 +480,19 @@ pub fn render_arrow(
 
     if debug {
         for seg in &path {
-            canvas.draw_line(seg.0, seg.1, &StyleAttr::debug2(),Option::None,);
-            canvas.draw_circle(seg.0, Point::new(6., 6.), &StyleAttr::debug1(),Option::None,);
-            canvas.draw_circle(seg.1, Point::new(6., 6.), &StyleAttr::debug1(),Option::None,);
+            canvas.draw_line(seg.0, seg.1, &StyleAttr::debug2(), Option::None);
+            canvas.draw_circle(
+                seg.0,
+                Point::new(6., 6.),
+                &StyleAttr::debug1(),
+                Option::None,
+            );
+            canvas.draw_circle(
+                seg.1,
+                Point::new(6., 6.),
+                &StyleAttr::debug1(),
+                Option::None,
+            );
         }
     }
 
@@ -496,5 +508,12 @@ pub fn render_arrow(
     let start = matches!(arrow.start, LineEndKind::Arrow);
     let end = matches!(arrow.end, LineEndKind::Arrow);
 
-    canvas.draw_arrow(&path, dash, (start, end), &arrow.look, arrow.properties.clone(),&arrow.text);
+    canvas.draw_arrow(
+        &path,
+        dash,
+        (start, end),
+        &arrow.look,
+        arrow.properties.clone(),
+        &arrow.text,
+    );
 }

--- a/layout/src/std_shapes/render.rs
+++ b/layout/src/std_shapes/render.rs
@@ -151,7 +151,7 @@ fn render_record(
             self.canvas.draw_rect(
                 Point::new(loc.x - size.x / 2., loc.y - size.y / 2.),
                 Point::new(size.x, size.y),
-                &self.look,
+                &self.look,Option::None,
                 self.clip_handle,
             );
         }
@@ -180,7 +180,7 @@ fn render_record(
     canvas.draw_rect(
         Point::new(loc.x - size.x / 2., loc.y - size.y / 2.),
         Point::new(size.x, size.y),
-        &look,
+        &look,Option::None,
         Option::None,
     );
 }
@@ -280,6 +280,7 @@ impl Renderable for Element {
                 bb.0,
                 self.pos.size(true),
                 &debug_look,
+                self.properties.clone(),
                 Option::None,
             );
         }
@@ -301,6 +302,7 @@ impl Renderable for Element {
                     self.pos.bbox(false).0,
                     self.pos.size(false),
                     &self.look,
+                    self.properties.clone(),
                     Option::None,
                 );
                 canvas.draw_text(self.pos.center(), text.as_str(), &self.look);
@@ -310,6 +312,7 @@ impl Renderable for Element {
                     self.pos.center(),
                     self.pos.size(false),
                     &self.look,
+                    self.properties.clone(),
                 );
                 canvas.draw_text(self.pos.center(), text.as_str(), &self.look);
             }
@@ -318,11 +321,13 @@ impl Renderable for Element {
                     self.pos.center(),
                     self.pos.size(false),
                     &self.look,
+                    self.properties.clone(),
                 );
                 canvas.draw_circle(
                     self.pos.center(),
                     self.pos.size(false).sub(Point::splat(15.)),
                     &self.look,
+                    Option::None,
                 );
                 canvas.draw_text(self.pos.center(), text.as_str(), &self.look);
             }
@@ -333,12 +338,14 @@ impl Renderable for Element {
                         self.pos.size(true),
                         &StyleAttr::debug0(),
                         Option::None,
+                        Option::None,
                     );
 
                     canvas.draw_rect(
                         self.pos.bbox(false).0,
                         self.pos.size(false),
                         &StyleAttr::debug1(),
+                        Option::None,
                         Option::None,
                     );
                 }
@@ -352,6 +359,7 @@ impl Renderable for Element {
                 self.pos.center(),
                 Point::new(6., 6.),
                 &StyleAttr::debug2(),
+                Option::None,
             );
         }
     }
@@ -470,9 +478,9 @@ pub fn render_arrow(
 
     if debug {
         for seg in &path {
-            canvas.draw_line(seg.0, seg.1, &StyleAttr::debug2());
-            canvas.draw_circle(seg.0, Point::new(6., 6.), &StyleAttr::debug1());
-            canvas.draw_circle(seg.1, Point::new(6., 6.), &StyleAttr::debug1());
+            canvas.draw_line(seg.0, seg.1, &StyleAttr::debug2(),Option::None,);
+            canvas.draw_circle(seg.0, Point::new(6., 6.), &StyleAttr::debug1(),Option::None,);
+            canvas.draw_circle(seg.1, Point::new(6., 6.), &StyleAttr::debug1(),Option::None,);
         }
     }
 
@@ -488,5 +496,5 @@ pub fn render_arrow(
     let start = matches!(arrow.start, LineEndKind::Arrow);
     let end = matches!(arrow.end, LineEndKind::Arrow);
 
-    canvas.draw_arrow(&path, dash, (start, end), &arrow.look, &arrow.text);
+    canvas.draw_arrow(&path, dash, (start, end), &arrow.look, arrow.properties.clone(),&arrow.text);
 }

--- a/layout/src/std_shapes/shapes.rs
+++ b/layout/src/std_shapes/shapes.rs
@@ -101,20 +101,11 @@ impl Element {
         look: StyleAttr,
         orientation: Orientation,
         size: Point,
-        properties:impl Into<String>,
+        properties: impl Into<String>,
     ) -> Element {
-        Element {
-            shape,
-            look,
-            orientation,
-            pos: Position::new(
-                Point::zero(),
-                size,
-                Point::zero(),
-                Point::splat(PADDING),
-            ),
-            properties: Option::Some(properties.into()),
-        }
+        let mut elem = Element::create(shape, look, orientation, size);
+        elem.properties = Option::Some(properties.into());
+        elem
     }
     pub fn create_connector(
         label: &str,
@@ -207,14 +198,13 @@ impl Arrow {
         }
     }
 
-
     pub fn with_properties(
         start: LineEndKind,
         end: LineEndKind,
         line_style: LineStyleKind,
         text: &str,
         look: &StyleAttr,
-        properties:impl Into<String>,
+        properties: impl Into<String>,
         src_port: &Option<String>,
         dst_port: &Option<String>,
     ) -> Arrow {
@@ -242,17 +232,13 @@ impl Arrow {
         )
     }
 
-    pub fn simple_with_properties(text: &str,properties:impl Into<String>) -> Arrow {
-        Arrow::with_properties(
-            LineEndKind::None,
-            LineEndKind::Arrow,
-            LineStyleKind::Normal,
-            text,
-            &StyleAttr::simple(),
-            properties,
-            &None,
-            &None,
-        )
+    pub fn simple_with_properties(
+        text: &str,
+        properties: impl Into<String>,
+    ) -> Arrow {
+        let mut arrow = Arrow::simple(text);
+        arrow.properties = Some(properties.into());
+        arrow
     }
 
     pub fn invisible() -> Arrow {

--- a/layout/src/std_shapes/shapes.rs
+++ b/layout/src/std_shapes/shapes.rs
@@ -72,6 +72,7 @@ pub struct Element {
     pub pos: Position,
     pub look: StyleAttr,
     pub orientation: Orientation,
+    pub properties: Option<String>,
 }
 
 impl Element {
@@ -91,6 +92,28 @@ impl Element {
                 Point::zero(),
                 Point::splat(PADDING),
             ),
+            properties: Option::None,
+        }
+    }
+
+    pub fn create_with_properties(
+        shape: ShapeKind,
+        look: StyleAttr,
+        orientation: Orientation,
+        size: Point,
+        properties:impl Into<String>,
+    ) -> Element {
+        Element {
+            shape,
+            look,
+            orientation,
+            pos: Position::new(
+                Point::zero(),
+                size,
+                Point::zero(),
+                Point::splat(PADDING),
+            ),
+            properties: Option::Some(properties.into()),
         }
     }
     pub fn create_connector(
@@ -108,6 +131,7 @@ impl Element {
                 Point::zero(),
                 Point::splat(CONN_PADDING),
             ),
+            properties: Option::None,
         }
     }
 
@@ -128,6 +152,7 @@ pub struct Arrow {
     pub line_style: LineStyleKind,
     pub text: String,
     pub look: StyleAttr,
+    pub properties: Option<String>,
     pub src_port: Option<String>,
     pub dst_port: Option<String>,
 }
@@ -140,6 +165,7 @@ impl Default for Arrow {
             line_style: LineStyleKind::Normal,
             text: String::new(),
             look: StyleAttr::simple(),
+            properties: Option::None,
             src_port: Option::None,
             dst_port: Option::None,
         }
@@ -154,6 +180,7 @@ impl Arrow {
             line_style: self.line_style,
             text: self.text.clone(),
             look: self.look.clone(),
+            properties: self.properties.clone(),
             src_port: self.dst_port.clone(),
             dst_port: self.src_port.clone(),
         }
@@ -174,6 +201,30 @@ impl Arrow {
             line_style,
             text: String::from(text),
             look: look.clone(),
+            properties: Option::None,
+            src_port: src_port.clone(),
+            dst_port: dst_port.clone(),
+        }
+    }
+
+
+    pub fn with_properties(
+        start: LineEndKind,
+        end: LineEndKind,
+        line_style: LineStyleKind,
+        text: &str,
+        look: &StyleAttr,
+        properties:impl Into<String>,
+        src_port: &Option<String>,
+        dst_port: &Option<String>,
+    ) -> Arrow {
+        Arrow {
+            start,
+            end,
+            line_style,
+            text: String::from(text),
+            look: look.clone(),
+            properties: Option::Some(properties.into()),
             src_port: src_port.clone(),
             dst_port: dst_port.clone(),
         }
@@ -186,6 +237,19 @@ impl Arrow {
             LineStyleKind::Normal,
             text,
             &StyleAttr::simple(),
+            &None,
+            &None,
+        )
+    }
+
+    pub fn simple_with_properties(text: &str,properties:impl Into<String>) -> Arrow {
+        Arrow::with_properties(
+            LineEndKind::None,
+            LineEndKind::Arrow,
+            LineStyleKind::Normal,
+            text,
+            &StyleAttr::simple(),
+            properties,
             &None,
             &None,
         )

--- a/src/bin/layout.rs
+++ b/src/bin/layout.rs
@@ -297,9 +297,9 @@ fn test7(offset_x: f64, offset_y: f64, svg: &mut SVGWriter) {
         let to = to.add(center).sub(Point::splat(200.));
 
         if segment_rect_intersection((from, to), es0.position().bbox(false)) {
-            svg.draw_line(from, to, &red,Option::None);
+            svg.draw_line(from, to, &red, Option::None);
         } else {
-            svg.draw_line(from, to, &StyleAttr::simple(),Option::None );
+            svg.draw_line(from, to, &StyleAttr::simple(), Option::None);
         }
     }
 }

--- a/src/bin/layout.rs
+++ b/src/bin/layout.rs
@@ -297,9 +297,9 @@ fn test7(offset_x: f64, offset_y: f64, svg: &mut SVGWriter) {
         let to = to.add(center).sub(Point::splat(200.));
 
         if segment_rect_intersection((from, to), es0.position().bbox(false)) {
-            svg.draw_line(from, to, &red);
+            svg.draw_line(from, to, &red,Option::None);
         } else {
-            svg.draw_line(from, to, &StyleAttr::simple());
+            svg.draw_line(from, to, &StyleAttr::simple(),Option::None );
         }
     }
 }


### PR DESCRIPTION
Hello!
I added `<g>` tag around vertices and edges in svg backend. [Here is the documentation for the tag](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/g) . As far as i understood this should not interfere with the rendering of the child elements.
`Element`s and `Arrow`s have now additional constructors with `properties:Optional<String>` argument to dictate the properties of the `<g>` tag.  

