### PR TITLE
Hyperlinks

### DIFF
--- a/inputs/hyperlink.dot
+++ b/inputs/hyperlink.dot
@@ -1,0 +1,7 @@
+graph {
+  label="Vincent van Gogh Paintings"
+  "Self-Portrait with Grey Felt Hat" [URL="https://www.vangoghmuseum.nl/en/collection/s0016V1962", fill="white"]
+  "Self-Portrait as a Painter" [URL="https://www.vangoghmuseum.nl/en/collection/s0022V1962", fill="white"]
+  "Sunflowers" [URL="https://www.nationalgallery.org.uk/paintings/vincent-van-gogh-sunflowers", fill="white"]
+  "Almond Blossom" [URL="https://www.vangoghmuseum.nl/en/collection/s0176V1962", fill="white"]
+}

--- a/layout/src/backends/svg.rs
+++ b/layout/src/backends/svg.rs
@@ -147,7 +147,8 @@ impl RenderBackend for SVGWriter {
         &mut self,
         xy: Point,
         size: Point,
-        look: &StyleAttr,
+        look: &StyleAttr, 
+        url: Option<&str>,
         clip: Option<ClipHandle>,
     ) {
         self.grow_window(xy, size);
@@ -174,10 +175,19 @@ impl RenderBackend for SVGWriter {
             rounded_px,
             clip_option
         );
-        self.content.push_str(&line1);
+        if let Some(url) = url {
+            let link = format!(
+                "<a href=\"{}\">\n  {}</a>\n",
+                url,
+                line1,
+            );
+            self.content.push_str(&link);
+        } else {
+            self.content.push_str(&line1);
+        }
     }
 
-    fn draw_circle(&mut self, xy: Point, size: Point, look: &StyleAttr) {
+    fn draw_circle(&mut self, xy: Point, size: Point, look: &StyleAttr, url: Option<&str>) {
         self.grow_window(xy, size);
         let fill_color = look.fill_color.unwrap_or_else(Color::transparent);
         let stroke_width = look.line_width;
@@ -194,7 +204,16 @@ impl RenderBackend for SVGWriter {
             stroke_width,
             stroke_color.to_web_color()
         );
-        self.content.push_str(&line1);
+        if let Some(url) = url {
+            let link = format!(
+                "<a href=\"{}\">\n  {}</a>\n",
+                url,
+                line1,
+            );
+            self.content.push_str(&link);
+        } else {
+            self.content.push_str(&line1);
+        }
     }
 
     fn draw_text(&mut self, xy: Point, text: &str, look: &StyleAttr) {

--- a/layout/src/backends/svg.rs
+++ b/layout/src/backends/svg.rs
@@ -147,7 +147,7 @@ impl RenderBackend for SVGWriter {
         &mut self,
         xy: Point,
         size: Point,
-        look: &StyleAttr, 
+        look: &StyleAttr,
         url: Option<&str>,
         clip: Option<ClipHandle>,
     ) {
@@ -176,18 +176,20 @@ impl RenderBackend for SVGWriter {
             clip_option
         );
         if let Some(url) = url {
-            let link = format!(
-                "<a href=\"{}\">\n  {}</a>\n",
-                url,
-                line1,
-            );
+            let link = format!("<a href=\"{}\">\n  {}</a>\n", url, line1,);
             self.content.push_str(&link);
         } else {
             self.content.push_str(&line1);
         }
     }
 
-    fn draw_circle(&mut self, xy: Point, size: Point, look: &StyleAttr, url: Option<&str>) {
+    fn draw_circle(
+        &mut self,
+        xy: Point,
+        size: Point,
+        look: &StyleAttr,
+        url: Option<&str>,
+    ) {
         self.grow_window(xy, size);
         let fill_color = look.fill_color.unwrap_or_else(Color::transparent);
         let stroke_width = look.line_width;
@@ -205,11 +207,7 @@ impl RenderBackend for SVGWriter {
             stroke_color.to_web_color()
         );
         if let Some(url) = url {
-            let link = format!(
-                "<a href=\"{}\">\n  {}</a>\n",
-                url,
-                line1,
-            );
+            let link = format!("<a href=\"{}\">\n  {}</a>\n", url, line1,);
             self.content.push_str(&link);
         } else {
             self.content.push_str(&line1);

--- a/layout/src/core/format.rs
+++ b/layout/src/core/format.rs
@@ -65,7 +65,7 @@ pub trait RenderBackend {
         &mut self,
         xy: Point,
         size: Point,
-        look: &StyleAttr, 
+        look: &StyleAttr,
         url: Option<&str>,
         clip: Option<ClipHandle>,
     );
@@ -74,7 +74,13 @@ pub trait RenderBackend {
     fn draw_line(&mut self, start: Point, stop: Point, look: &StyleAttr);
 
     /// Draw an ellipse with the center \p xy, and size \p size.
-    fn draw_circle(&mut self, xy: Point, size: Point, look: &StyleAttr, url: Option<&str>);
+    fn draw_circle(
+        &mut self,
+        xy: Point,
+        size: Point,
+        look: &StyleAttr,
+        url: Option<&str>,
+    );
 
     /// Draw a labe.
     fn draw_text(&mut self, xy: Point, text: &str, look: &StyleAttr);

--- a/layout/src/core/format.rs
+++ b/layout/src/core/format.rs
@@ -65,7 +65,8 @@ pub trait RenderBackend {
         &mut self,
         xy: Point,
         size: Point,
-        look: &StyleAttr,
+        look: &StyleAttr, 
+        url: Option<&str>,
         clip: Option<ClipHandle>,
     );
 
@@ -73,7 +74,7 @@ pub trait RenderBackend {
     fn draw_line(&mut self, start: Point, stop: Point, look: &StyleAttr);
 
     /// Draw an ellipse with the center \p xy, and size \p size.
-    fn draw_circle(&mut self, xy: Point, size: Point, look: &StyleAttr);
+    fn draw_circle(&mut self, xy: Point, size: Point, look: &StyleAttr, url: Option<&str>);
 
     /// Draw a labe.
     fn draw_text(&mut self, xy: Point, text: &str, look: &StyleAttr);

--- a/layout/src/gv/builder.rs
+++ b/layout/src/gv/builder.rs
@@ -362,6 +362,8 @@ impl GraphBuilder {
             }
         }
 
+        let url = lst.get(&"URL".to_string()).cloned();
+
         // We flip the orientation before we create the shape. In graphs that
         // grow top down the records grow to the left.
         let dir = dir.flip();
@@ -374,6 +376,6 @@ impl GraphBuilder {
             rounded_corder_value,
             font_size,
         );
-        Element::create(shape, look, dir, sz)
+        Element::create(shape, look, url, dir, sz)
     }
 }

--- a/layout/src/std_shapes/render.rs
+++ b/layout/src/std_shapes/render.rs
@@ -128,11 +128,13 @@ fn render_record(
     dir: Orientation,
     loc: Point,
     size: Point,
+    url: Option<&str>,
     look: &StyleAttr,
     canvas: &mut dyn RenderBackend,
 ) {
     struct Renderer<'a> {
         look: StyleAttr,
+        url: Option<&'a str>,
         clip_handle: Option<ClipHandle>,
         canvas: &'a mut dyn RenderBackend,
     }
@@ -151,7 +153,8 @@ fn render_record(
             self.canvas.draw_rect(
                 Point::new(loc.x - size.x / 2., loc.y - size.y / 2.),
                 Point::new(size.x, size.y),
-                &self.look,
+                &self.look, 
+                self.url,
                 self.clip_handle,
             );
         }
@@ -168,6 +171,7 @@ fn render_record(
 
     let mut visitor = Renderer {
         look: look.clone(),
+        url,
         clip_handle,
         canvas,
     };
@@ -180,7 +184,8 @@ fn render_record(
     canvas.draw_rect(
         Point::new(loc.x - size.x / 2., loc.y - size.y / 2.),
         Point::new(size.x, size.y),
-        &look,
+        &look, 
+        url,
         Option::None,
     );
 }
@@ -279,7 +284,8 @@ impl Renderable for Element {
             canvas.draw_rect(
                 bb.0,
                 self.pos.size(true),
-                &debug_look,
+                &debug_look, 
+                None,
                 Option::None,
             );
         }
@@ -292,6 +298,7 @@ impl Renderable for Element {
                     self.orientation,
                     self.pos.center(),
                     self.pos.size(false),
+                    self.url.as_deref(),
                     &self.look,
                     canvas,
                 );
@@ -301,6 +308,7 @@ impl Renderable for Element {
                     self.pos.bbox(false).0,
                     self.pos.size(false),
                     &self.look,
+                    self.url.as_deref(),
                     Option::None,
                 );
                 canvas.draw_text(self.pos.center(), text.as_str(), &self.look);
@@ -310,6 +318,7 @@ impl Renderable for Element {
                     self.pos.center(),
                     self.pos.size(false),
                     &self.look,
+                    self.url.as_deref(),
                 );
                 canvas.draw_text(self.pos.center(), text.as_str(), &self.look);
             }
@@ -318,11 +327,13 @@ impl Renderable for Element {
                     self.pos.center(),
                     self.pos.size(false),
                     &self.look,
+                    self.url.as_deref(),
                 );
                 canvas.draw_circle(
                     self.pos.center(),
                     self.pos.size(false).sub(Point::splat(15.)),
                     &self.look,
+                    Option::None,
                 );
                 canvas.draw_text(self.pos.center(), text.as_str(), &self.look);
             }
@@ -333,12 +344,14 @@ impl Renderable for Element {
                         self.pos.size(true),
                         &StyleAttr::debug0(),
                         Option::None,
+                        Option::None,
                     );
 
                     canvas.draw_rect(
                         self.pos.bbox(false).0,
                         self.pos.size(false),
                         &StyleAttr::debug1(),
+                        Option::None,
                         Option::None,
                     );
                 }
@@ -352,6 +365,7 @@ impl Renderable for Element {
                 self.pos.center(),
                 Point::new(6., 6.),
                 &StyleAttr::debug2(),
+                Option::None,
             );
         }
     }
@@ -471,8 +485,8 @@ pub fn render_arrow(
     if debug {
         for seg in &path {
             canvas.draw_line(seg.0, seg.1, &StyleAttr::debug2());
-            canvas.draw_circle(seg.0, Point::new(6., 6.), &StyleAttr::debug1());
-            canvas.draw_circle(seg.1, Point::new(6., 6.), &StyleAttr::debug1());
+            canvas.draw_circle(seg.0, Point::new(6., 6.), &StyleAttr::debug1(), Option::None);
+            canvas.draw_circle(seg.1, Point::new(6., 6.), &StyleAttr::debug1(), Option::None);
         }
     }
 

--- a/layout/src/std_shapes/render.rs
+++ b/layout/src/std_shapes/render.rs
@@ -153,7 +153,7 @@ fn render_record(
             self.canvas.draw_rect(
                 Point::new(loc.x - size.x / 2., loc.y - size.y / 2.),
                 Point::new(size.x, size.y),
-                &self.look, 
+                &self.look,
                 self.url,
                 self.clip_handle,
             );
@@ -184,7 +184,7 @@ fn render_record(
     canvas.draw_rect(
         Point::new(loc.x - size.x / 2., loc.y - size.y / 2.),
         Point::new(size.x, size.y),
-        &look, 
+        &look,
         url,
         Option::None,
     );
@@ -284,7 +284,7 @@ impl Renderable for Element {
             canvas.draw_rect(
                 bb.0,
                 self.pos.size(true),
-                &debug_look, 
+                &debug_look,
                 None,
                 Option::None,
             );
@@ -485,8 +485,18 @@ pub fn render_arrow(
     if debug {
         for seg in &path {
             canvas.draw_line(seg.0, seg.1, &StyleAttr::debug2());
-            canvas.draw_circle(seg.0, Point::new(6., 6.), &StyleAttr::debug1(), Option::None);
-            canvas.draw_circle(seg.1, Point::new(6., 6.), &StyleAttr::debug1(), Option::None);
+            canvas.draw_circle(
+                seg.0,
+                Point::new(6., 6.),
+                &StyleAttr::debug1(),
+                Option::None,
+            );
+            canvas.draw_circle(
+                seg.1,
+                Point::new(6., 6.),
+                &StyleAttr::debug1(),
+                Option::None,
+            );
         }
     }
 

--- a/layout/src/std_shapes/shapes.rs
+++ b/layout/src/std_shapes/shapes.rs
@@ -71,6 +71,7 @@ pub struct Element {
     pub shape: ShapeKind,
     pub pos: Position,
     pub look: StyleAttr,
+    pub url: Option<String>,
     pub orientation: Orientation,
 }
 
@@ -78,12 +79,14 @@ impl Element {
     pub fn create(
         shape: ShapeKind,
         look: StyleAttr,
+        url: Option<String>,
         orientation: Orientation,
         size: Point,
     ) -> Element {
         Element {
             shape,
             look,
+            url,
             orientation,
             pos: Position::new(
                 Point::zero(),
@@ -101,6 +104,7 @@ impl Element {
         Element {
             shape: ShapeKind::new_connector(label),
             look: look.clone(),
+            url: None,
             orientation: dir,
             pos: Position::new(
                 Point::zero(),
@@ -113,6 +117,11 @@ impl Element {
 
     pub fn empty_connector(dir: Orientation) -> Element {
         Self::create_connector("", &StyleAttr::simple(), dir)
+    }
+
+    // Add an URL to form a hyperlink
+    pub fn set_url(&mut self, url: String) {
+        self.url = Some(url);        
     }
 
     // Make the center of the shape point to \p to.

--- a/layout/src/std_shapes/shapes.rs
+++ b/layout/src/std_shapes/shapes.rs
@@ -121,7 +121,7 @@ impl Element {
 
     // Add an URL to form a hyperlink
     pub fn set_url(&mut self, url: String) {
-        self.url = Some(url);        
+        self.url = Some(url);
     }
 
     // Make the center of the shape point to \p to.

--- a/src/bin/layout.rs
+++ b/src/bin/layout.rs
@@ -50,7 +50,8 @@ fn test0(offset_x: f64, offset_y: f64, svg: &mut SVGWriter, shape_idx: usize) {
         };
 
         let look = StyleAttr::simple();
-        let mut es = Element::create(sp, look, None, Orientation::LeftToRight, sz);
+        let mut es =
+            Element::create(sp, look, None, Orientation::LeftToRight, sz);
         es.position_mut().move_to(loc);
         shapes.push(es);
     }
@@ -80,8 +81,10 @@ fn test1(offset_x: f64, offset_y: f64, svg: &mut SVGWriter) {
     look1.fill_color = Some(Color::fast("olive"));
     look1.line_color = Color::fast("brown");
 
-    let mut es0 = Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
-    let mut es1 = Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
+    let mut es0 =
+        Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
+    let mut es1 =
+        Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
 
     let loc0 = Point::new(offset_x, offset_y);
     let loc1 = Point::new(offset_x, offset_y + 150.);
@@ -115,8 +118,10 @@ fn test3(
     look1.fill_color = Some(Color::fast("olive"));
     look1.line_color = Color::fast("brown");
 
-    let mut es0 = Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
-    let mut es1 = Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
+    let mut es0 =
+        Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
+    let mut es1 =
+        Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
 
     let loc0 = Point::new(offset_x, offset_y);
     let loc1 = Point::new(offset_x + offset_x_other, offset_y + 150.);
@@ -151,8 +156,10 @@ fn test4(
     look1.fill_color = Some(Color::fast("lightblue"));
     look1.line_color = Color::fast("black");
 
-    let mut es0 = Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
-    let mut es1 = Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
+    let mut es0 =
+        Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
+    let mut es1 =
+        Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
 
     let loc0 = Point::new(offset_x, offset_y);
     let loc1 = Point::new(offset_x + offset_x_other, offset_y + 150.);
@@ -189,8 +196,10 @@ fn test5(
     look1.fill_color = Some(Color::fast("salmon"));
     look1.line_color = Color::fast("black");
 
-    let mut es0 = Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
-    let mut es1 = Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
+    let mut es0 =
+        Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
+    let mut es1 =
+        Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
     let mut inv = Element::empty_connector(Orientation::LeftToRight);
 
     let mut loc0 = Point::new(offset_x, offset_y);
@@ -229,8 +238,10 @@ fn test6(
 
     let rec0 = generate_record();
     let rec1 = generate_record();
-    let mut es0 = Element::create(rec0, look0, None, Orientation::LeftToRight, sz);
-    let mut es1 = Element::create(rec1, look1, None, Orientation::LeftToRight, sz);
+    let mut es0 =
+        Element::create(rec0, look0, None, Orientation::LeftToRight, sz);
+    let mut es1 =
+        Element::create(rec1, look1, None, Orientation::LeftToRight, sz);
     let mut inv = Element::empty_connector(Orientation::LeftToRight);
 
     let loc0 = Point::new(offset_x, offset_y);
@@ -270,7 +281,8 @@ fn test7(offset_x: f64, offset_y: f64, svg: &mut SVGWriter) {
     red.line_color = Color::fast("red");
 
     let sz = Point::splat(100.);
-    let mut es0 = Element::create(sp, look1, None, Orientation::LeftToRight, sz);
+    let mut es0 =
+        Element::create(sp, look1, None, Orientation::LeftToRight, sz);
     let center = Point::new(offset_x, offset_y);
     es0.move_to(center);
     es0.render(false, svg);
@@ -321,7 +333,8 @@ fn test8(offset_x: f64, offset_y: f64, svg: &mut SVGWriter) {
     look1.fill_color = Some(Color::fast("steelblue"));
     look1.line_color = Color::fast("white");
 
-    let mut es0 = Element::create(rec0, look1, None, Orientation::LeftToRight, sz);
+    let mut es0 =
+        Element::create(rec0, look1, None, Orientation::LeftToRight, sz);
 
     let loc0 = Point::new(offset_x, offset_y);
     es0.move_to(loc0);

--- a/src/bin/layout.rs
+++ b/src/bin/layout.rs
@@ -50,7 +50,7 @@ fn test0(offset_x: f64, offset_y: f64, svg: &mut SVGWriter, shape_idx: usize) {
         };
 
         let look = StyleAttr::simple();
-        let mut es = Element::create(sp, look, Orientation::LeftToRight, sz);
+        let mut es = Element::create(sp, look, None, Orientation::LeftToRight, sz);
         es.position_mut().move_to(loc);
         shapes.push(es);
     }
@@ -80,8 +80,8 @@ fn test1(offset_x: f64, offset_y: f64, svg: &mut SVGWriter) {
     look1.fill_color = Some(Color::fast("olive"));
     look1.line_color = Color::fast("brown");
 
-    let mut es0 = Element::create(sp0, look0, Orientation::LeftToRight, sz);
-    let mut es1 = Element::create(sp1, look1, Orientation::LeftToRight, sz);
+    let mut es0 = Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
+    let mut es1 = Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
 
     let loc0 = Point::new(offset_x, offset_y);
     let loc1 = Point::new(offset_x, offset_y + 150.);
@@ -115,8 +115,8 @@ fn test3(
     look1.fill_color = Some(Color::fast("olive"));
     look1.line_color = Color::fast("brown");
 
-    let mut es0 = Element::create(sp0, look0, Orientation::LeftToRight, sz);
-    let mut es1 = Element::create(sp1, look1, Orientation::LeftToRight, sz);
+    let mut es0 = Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
+    let mut es1 = Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
 
     let loc0 = Point::new(offset_x, offset_y);
     let loc1 = Point::new(offset_x + offset_x_other, offset_y + 150.);
@@ -151,8 +151,8 @@ fn test4(
     look1.fill_color = Some(Color::fast("lightblue"));
     look1.line_color = Color::fast("black");
 
-    let mut es0 = Element::create(sp0, look0, Orientation::LeftToRight, sz);
-    let mut es1 = Element::create(sp1, look1, Orientation::LeftToRight, sz);
+    let mut es0 = Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
+    let mut es1 = Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
 
     let loc0 = Point::new(offset_x, offset_y);
     let loc1 = Point::new(offset_x + offset_x_other, offset_y + 150.);
@@ -189,8 +189,8 @@ fn test5(
     look1.fill_color = Some(Color::fast("salmon"));
     look1.line_color = Color::fast("black");
 
-    let mut es0 = Element::create(sp0, look0, Orientation::LeftToRight, sz);
-    let mut es1 = Element::create(sp1, look1, Orientation::LeftToRight, sz);
+    let mut es0 = Element::create(sp0, look0, None, Orientation::LeftToRight, sz);
+    let mut es1 = Element::create(sp1, look1, None, Orientation::LeftToRight, sz);
     let mut inv = Element::empty_connector(Orientation::LeftToRight);
 
     let mut loc0 = Point::new(offset_x, offset_y);
@@ -229,8 +229,8 @@ fn test6(
 
     let rec0 = generate_record();
     let rec1 = generate_record();
-    let mut es0 = Element::create(rec0, look0, Orientation::LeftToRight, sz);
-    let mut es1 = Element::create(rec1, look1, Orientation::LeftToRight, sz);
+    let mut es0 = Element::create(rec0, look0, None, Orientation::LeftToRight, sz);
+    let mut es1 = Element::create(rec1, look1, None, Orientation::LeftToRight, sz);
     let mut inv = Element::empty_connector(Orientation::LeftToRight);
 
     let loc0 = Point::new(offset_x, offset_y);
@@ -270,7 +270,7 @@ fn test7(offset_x: f64, offset_y: f64, svg: &mut SVGWriter) {
     red.line_color = Color::fast("red");
 
     let sz = Point::splat(100.);
-    let mut es0 = Element::create(sp, look1, Orientation::LeftToRight, sz);
+    let mut es0 = Element::create(sp, look1, None, Orientation::LeftToRight, sz);
     let center = Point::new(offset_x, offset_y);
     es0.move_to(center);
     es0.render(false, svg);
@@ -321,7 +321,7 @@ fn test8(offset_x: f64, offset_y: f64, svg: &mut SVGWriter) {
     look1.fill_color = Some(Color::fast("steelblue"));
     look1.line_color = Color::fast("white");
 
-    let mut es0 = Element::create(rec0, look1, Orientation::LeftToRight, sz);
+    let mut es0 = Element::create(rec0, look1, None, Orientation::LeftToRight, sz);
 
     let loc0 = Point::new(offset_x, offset_y);
     es0.move_to(loc0);


### PR DESCRIPTION
This adds hyperlinks to graph generation. 
The [`URL`](https://graphviz.org/docs/attrs/URL/) property of the graphs is parsed and stored, and rendered as an additional `<a>` SVG element.
This is visible in the rendering of the  `3.dot` and `hyperlink.dot` examples.