### PR TITLE
adds fill=context-stroke to SVG markers

### DIFF
--- a/layout/src/backends/svg.rs
+++ b/layout/src/backends/svg.rs
@@ -12,11 +12,11 @@ static SVG_HEADER: &str =
 static SVG_DEFS: &str = r#"<defs>
 <marker id="startarrow" markerWidth="10" markerHeight="7"
 refX="0" refY="3.5" orient="auto">
-<polygon points="10 0, 10 7, 0 3.5" />
+<polygon points="10 0, 10 7, 0 3.5" fill="context-stroke" />
 </marker>
 <marker id="endarrow" markerWidth="10" markerHeight="7"
 refX="10" refY="3.5" orient="auto">
-<polygon points="0 0, 10 3.5, 0 7" />
+<polygon points="0 0, 10 3.5, 0 7" fill="context-stroke" />
 </marker>
 
 </defs>"#;


### PR DESCRIPTION
This PR is a minor change to address #28.  It adds an indicator to the SVG arrow ends to match the color of the given line where the option is supported.

Here is an example of the arrow before the change:
![Screenshot 2024-06-14 at 12 29 04 PM](https://github.com/nadavrot/layout/assets/649567/5996066b-6d8a-487a-8d8b-1b0f742cc997)

And the same example after the change:
![Screenshot 2024-06-14 at 12 30 54 PM](https://github.com/nadavrot/layout/assets/649567/ffb78b06-5851-4b2f-b104-60bcaf43f0f1)
