### PR TITLE
Add Debug impl's for all public structs.

### DIFF
--- a/layout/src/adt/dag.rs
+++ b/layout/src/adt/dag.rs
@@ -269,8 +269,6 @@ impl DAG {
         }
 
         while let Some((current, cmd)) = worklist.pop() {
-            
-
             // Handle 'push' commands.
             if cmd {
                 order.push(current);

--- a/layout/src/adt/dag.rs
+++ b/layout/src/adt/dag.rs
@@ -265,8 +265,8 @@ impl DAG {
             worklist.push((n, false));
         }
 
-        while !worklist.is_empty() {
-            let (current, cmd) = worklist.pop().unwrap();
+        while let Some((current, cmd)) = worklist.pop() {
+            
 
             // Handle 'push' commands.
             if cmd {

--- a/layout/src/adt/dag.rs
+++ b/layout/src/adt/dag.rs
@@ -7,6 +7,7 @@
 use std::cmp;
 
 /// The Ranked-DAG data structure.
+#[derive(Debug)]
 pub struct DAG {
     /// A list of nodes in the dag.
     nodes: Vec<Node>,
@@ -39,6 +40,7 @@ impl From<usize> for NodeHandle {
     }
 }
 
+#[derive(Debug)]
 struct Node {
     // Points to other edges.
     successors: Vec<NodeHandle>,
@@ -57,6 +59,7 @@ impl Node {
 }
 
 /// Node iterator for iterating over nodes in the graph.
+#[derive(Debug)]
 pub struct NodeIterator {
     curr: usize,
     last: usize,

--- a/layout/src/adt/map.rs
+++ b/layout/src/adt/map.rs
@@ -6,6 +6,7 @@ use std::hash::Hash;
 
 /// Scoped map that supports inserting and removing lots of key-val pairs
 /// at once.
+#[derive(Debug)]
 pub struct ScopedMap<K, V> {
     stack: Vec<Vec<(K, V)>>,
 }

--- a/layout/src/backends/svg.rs
+++ b/layout/src/backends/svg.rs
@@ -50,6 +50,7 @@ fn escape_string(x: &str) -> String {
     res
 }
 
+#[derive(Debug)]
 pub struct SVGWriter {
     content: String,
     view_size: Point,

--- a/layout/src/core/color.rs
+++ b/layout/src/core/color.rs
@@ -151,7 +151,7 @@ static KNOWN_COLORS: [(&str, u32); 148] = [
     ("yellowgreen", 0x9acd32),
 ];
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub struct Color {
     // Color in the format RGBA
     color: u32,

--- a/layout/src/core/style.rs
+++ b/layout/src/core/style.rs
@@ -2,7 +2,7 @@
 
 use crate::core::color::Color;
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum LineStyleKind {
     Normal,
     Dashed,
@@ -10,8 +10,7 @@ pub enum LineStyleKind {
     None,
 }
 
-#[derive(Clone)]
-
+#[derive(Clone, Debug)]
 pub struct StyleAttr {
     pub line_color: Color,
     pub line_width: usize,

--- a/layout/src/gv/builder.rs
+++ b/layout/src/gv/builder.rs
@@ -19,6 +19,7 @@ type PropertyList = HashMap<String, String>;
 // AST into the VisualGraph data-structure that we use for layout and rendering
 // of the graph.
 
+#[derive(Debug)]
 struct EdgeDesc {
     from: String,
     to: String,
@@ -29,6 +30,7 @@ struct EdgeDesc {
 }
 
 /// This class constructs a visual graph from the parsed AST.
+#[derive(Debug)]
 pub struct GraphBuilder {
     // This records the state of the top-level graph.
     global_state: PropertyList,

--- a/layout/src/gv/parser/lexer.rs
+++ b/layout/src/gv/parser/lexer.rs
@@ -23,6 +23,7 @@ pub enum Token {
     Error(usize),
 }
 
+#[derive(Debug)]
 pub struct Lexer {
     input: Vec<char>,
     pub pos: usize,

--- a/layout/src/gv/parser/parser.rs
+++ b/layout/src/gv/parser/parser.rs
@@ -2,6 +2,7 @@ use super::ast;
 use super::lexer::Lexer;
 use super::lexer::Token;
 
+#[derive(Debug)]
 pub struct DotParser {
     lexer: Lexer,
     tok: Token,

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -103,6 +103,8 @@ fn simple_graph() {
 
 */
 
+#![warn(missing_debug_implementations)]
+
 pub mod adt;
 pub mod backends;
 pub mod core;

--- a/layout/src/std_shapes/shapes.rs
+++ b/layout/src/std_shapes/shapes.rs
@@ -12,13 +12,13 @@ use crate::std_shapes::render::get_shape_size;
 const PADDING: f64 = 60.;
 const CONN_PADDING: f64 = 10.;
 
-#[derive(Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum LineEndKind {
     None,
     Arrow,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum RecordDef {
     // Label, port:
     Text(String, Option<String>),
@@ -35,7 +35,7 @@ impl RecordDef {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum ShapeKind {
     None,
     Box(String),
@@ -66,7 +66,7 @@ impl ShapeKind {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Element {
     pub shape: ShapeKind,
     pub pos: Position,
@@ -136,7 +136,7 @@ impl Element {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Arrow {
     pub start: LineEndKind,
     pub end: LineEndKind,

--- a/layout/src/topo/layout.rs
+++ b/layout/src/topo/layout.rs
@@ -22,6 +22,7 @@ use std::vec;
 
 use super::placer::Placer;
 
+#[derive(Debug)]
 pub struct VisualGraph {
     // Holds all of the elements in the graph.
     nodes: Vec<Element>,

--- a/layout/src/topo/optimizer.rs
+++ b/layout/src/topo/optimizer.rs
@@ -10,6 +10,7 @@ use crate::core::base::Direction;
 /// This optimizations changes the order of nodes within a rank (ordering along
 /// the x-axis). The transformation tries to reduce the number of edges that
 /// cross each other.
+#[derive(Debug)]
 pub struct EdgeCrossOptimizer<'a> {
     dag: &'a mut DAG,
 }
@@ -212,6 +213,7 @@ impl<'a> EdgeCrossOptimizer<'a> {
 
 /// This optimization sinks nodes in an attempt to shorten the length of edges
 /// that run through the graph.
+#[derive(Debug)]
 pub struct RankOptimizer<'a> {
     dag: &'a mut DAG,
 }

--- a/layout/src/topo/placer/mod.rs
+++ b/layout/src/topo/placer/mod.rs
@@ -5,7 +5,7 @@ pub const EPSILON: f64 = 0.001;
 
 /// Categorizes blocks to visible and invisible. We use this enum to tell the
 /// passes which blocks they are allowed to touch.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum BlockKind {
     Box,
     Connector,

--- a/layout/src/topo/placer/place.rs
+++ b/layout/src/topo/placer/place.rs
@@ -11,6 +11,7 @@ use crate::topo::placer::move_between_rows;
 use crate::topo::placer::simple;
 use crate::topo::placer::verifier;
 
+#[derive(Debug)]
 pub struct Placer<'a> {
     vg: &'a mut VisualGraph,
 }


### PR DESCRIPTION
This is really nice to have when working with a library. I also added a `#![warn(missing_debug_implementations)]` to help enforce this in the future.