### PR TITLE
Level query optimization

### DIFF
--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -13,7 +13,12 @@ fn test_main(n_node: usize, _n_edge: usize) {
     let mut gb = VisualGraph::new(Orientation::LeftToRight);
 
     for i in 0..n_node {
-        let elem = Element::create(ShapeKind::Circle(format!("hi_{}", i)), StyleAttr::new(Color::transparent(), 0, None, 0, 0), Orientation::LeftToRight, Point::zero());
+        let elem = Element::create(
+            ShapeKind::Circle(format!("hi_{}", i)),
+            StyleAttr::new(Color::transparent(), 0, None, 0, 0),
+            Orientation::LeftToRight,
+            Point::zero(),
+        );
         gb.add_node(elem);
     }
     let t0 = std::time::Instant::now();
@@ -23,20 +28,15 @@ fn test_main(n_node: usize, _n_edge: usize) {
     let duration = t0.elapsed();
     println!("Time elapsed in expensive_function() is: {:?}", duration);
     println!("--------------------------------------");
-
 }
+use layout::std_shapes::shapes::{Element, ShapeKind};
 use layout::topo::layout::VisualGraph;
-use layout::std_shapes::shapes::{
-    Element, ShapeKind
-};
-
 
 fn main() {
     // let n_node = 16;
     let n_edge = 16;
     for n_node in [16, 32, 64, 128, 256, 512, 1024, 2048, 4096] {
         test_main(n_node, n_edge);
-
     }
 
     // let content = svg.finalize();

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -33,19 +33,8 @@ use layout::std_shapes::shapes::{Element, ShapeKind};
 use layout::topo::layout::VisualGraph;
 
 fn main() {
-    // let n_node = 16;
     let n_edge = 16;
     for n_node in [16, 32, 64, 128, 256, 512, 1024, 2048, 4096] {
         test_main(n_node, n_edge);
     }
-
-    // let content = svg.finalize();
-    // let filename = "./shapes.svg";
-    // let res = save_to_file(filename, &content);
-    // if let Result::Err(err) = res {
-    //     log::error!("Could not write the file {}", filename);
-    //     log::error!("Error {}", err);
-    //     return;
-    // }
-    // log::info!("Wrote {}", filename);
 }

--- a/examples/benchmark.rs
+++ b/examples/benchmark.rs
@@ -1,0 +1,51 @@
+//! This is a sample program that prints a bunch of elements to an SVG file so
+//! we can visually see if the things that we render look right.
+
+use layout::backends::svg::SVGWriter;
+use layout::core::base::Orientation;
+use layout::core::color::Color;
+use layout::core::geometry::Point;
+use layout::core::style::StyleAttr;
+pub const LAYOUT_HELPER: bool = true;
+
+fn test_main(n_node: usize, _n_edge: usize) {
+    let mut svg = SVGWriter::new();
+    let mut gb = VisualGraph::new(Orientation::LeftToRight);
+
+    for i in 0..n_node {
+        let elem = Element::create(ShapeKind::Circle(format!("hi_{}", i)), StyleAttr::new(Color::transparent(), 0, None, 0, 0), Orientation::LeftToRight, Point::zero());
+        gb.add_node(elem);
+    }
+    let t0 = std::time::Instant::now();
+
+    gb.do_it(false, true, false, &mut svg);
+
+    let duration = t0.elapsed();
+    println!("Time elapsed in expensive_function() is: {:?}", duration);
+    println!("--------------------------------------");
+
+}
+use layout::topo::layout::VisualGraph;
+use layout::std_shapes::shapes::{
+    Element, ShapeKind
+};
+
+
+fn main() {
+    // let n_node = 16;
+    let n_edge = 16;
+    for n_node in [16, 32, 64, 128, 256, 512, 1024, 2048, 4096] {
+        test_main(n_node, n_edge);
+
+    }
+
+    // let content = svg.finalize();
+    // let filename = "./shapes.svg";
+    // let res = save_to_file(filename, &content);
+    // if let Result::Err(err) = res {
+    //     log::error!("Could not write the file {}", filename);
+    //     log::error!("Error {}", err);
+    //     return;
+    // }
+    // log::info!("Wrote {}", filename);
+}

--- a/layout/src/adt/dag.rs
+++ b/layout/src/adt/dag.rs
@@ -15,6 +15,9 @@ pub struct DAG {
     /// Places nodes in levels.
     ranks: RankType,
 
+    /// levels info
+    levels: Vec<usize>,
+
     /// Perform validation checks.
     validate: bool,
 }
@@ -84,6 +87,7 @@ impl DAG {
         DAG {
             nodes: Vec::new(),
             ranks: Vec::new(),
+            levels: Vec::new(),
             validate: true,
         }
     }
@@ -95,6 +99,7 @@ impl DAG {
     pub fn clear(&mut self) {
         self.nodes.clear();
         self.ranks.clear();
+        self.levels.clear();
     }
 
     pub fn iter(&self) -> NodeIterator {
@@ -136,6 +141,7 @@ impl DAG {
     /// Create a new node.
     pub fn new_node(&mut self) -> NodeHandle {
         self.nodes.push(Node::new());
+        self.levels.push(0);
         let node = NodeHandle::new(self.nodes.len() - 1);
         self.add_element_to_rank(node, 0, false);
         node
@@ -145,6 +151,7 @@ impl DAG {
     pub fn new_nodes(&mut self, n: usize) {
         for _ in 0..n {
             self.nodes.push(Node::new());
+            self.levels.push(0);
             let node = NodeHandle::new(self.nodes.len() - 1);
             self.add_element_to_rank(node, 0, false);
         }
@@ -362,6 +369,7 @@ impl DAG {
         } else {
             self.ranks[level].push(elem);
         }
+        self.levels[elem.get_index()] = level;
     }
 
     /// Places all of the nodes in ranks (levels).
@@ -411,6 +419,7 @@ impl DAG {
             for i in 0..row.len() {
                 if row[i] == marker {
                     row.insert(i, node);
+                    self.levels[node.get_index()] = new_level;
                     return;
                 }
             }
@@ -418,18 +427,20 @@ impl DAG {
         }
 
         self.ranks[new_level].push(node);
+        self.levels[node.get_index()] = new_level;
         assert_eq!(self.level(node), new_level);
     }
 
     /// \returns the level of the node \p node in the rank.
     pub fn level(&self, node: NodeHandle) -> usize {
         assert!(node.get_index() < self.len(), "Node not in the dag");
-        for (i, row) in self.ranks.iter().enumerate() {
-            if row.contains(&node) {
-                return i;
-            }
-        }
-        panic!("Unexpected node. Is the graph ranked?");
+        self.levels[node.get_index()]
+        // for (i, row) in self.ranks.iter().enumerate() {
+        //     if row.contains(&node) {
+        //         return i;
+        //     }
+        // }
+        // panic!("Unexpected node. Is the graph ranked?");
     }
 
     /// Computes and returns the level of each node in the graph based

--- a/layout/src/adt/dag.rs
+++ b/layout/src/adt/dag.rs
@@ -435,12 +435,6 @@ impl DAG {
     pub fn level(&self, node: NodeHandle) -> usize {
         assert!(node.get_index() < self.len(), "Node not in the dag");
         self.levels[node.get_index()]
-        // for (i, row) in self.ranks.iter().enumerate() {
-        //     if row.contains(&node) {
-        //         return i;
-        //     }
-        // }
-        // panic!("Unexpected node. Is the graph ranked?");
     }
 
     /// Computes and returns the level of each node in the graph based

--- a/layout/src/topo/optimizer.rs
+++ b/layout/src/topo/optimizer.rs
@@ -78,6 +78,7 @@ impl<'a> EdgeCrossOptimizer<'a> {
         self.dag.verify();
         #[cfg(feature = "log")]
         log::info!("Optimizing edge crossing.");
+        // this is only shuffle no need to update levels
         let mut best_rank = self.dag.ranks().clone();
         let mut best_cnt = self.count_crossed_edges();
         #[cfg(feature = "log")]


### PR DESCRIPTION
Introduced new field to optimize query of node levels. You can check the simple benchmark script to see the comparison.
The old method of level makes the runtime complextity of schedule O(n^3) with n being number of nodes. New level -> O(n^2)

But, this new field also introduces an invariant that the Dag struct has to maintain

Part of the problem is that rank can be borrow mutably in public api and be used to change and break invariant.

So, to keep the invariant (in this commit), we might need a resign around this issue, possible a breaking of public api.

Curious about your feedback.